### PR TITLE
CPP: Fixes for C++: Mishandling Japanese Era and Leap Year in calculations #1354

### DIFF
--- a/cpp/ql/src/Likely Bugs/Leap Year/Adding365daysPerYear.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/Adding365daysPerYear.qhelp
@@ -1,0 +1,20 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+  <include src="LeapYear.qhelp" />
+
+<p>When performing arithmetic operations on a variable that represents a date, leap years must be taken into account.
+It is not safe to assume that a year is 365 days long.</p>
+</overview>
+
+<recommendation>
+<p>Determine whether the time span in question contains a leap day, then perform the calculation using the correct number
+of days.  Alternatively, use an established library routine that already contains correct leap year logic.</p>
+</recommendation>
+
+<references>
+  <include src="LeapYearReferences.qhelp" />
+</references>
+</qhelp>

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp
@@ -2,15 +2,9 @@
   "-//Semmle//qhelp//EN"
   "qhelp.dtd">
 <qhelp>
-  <overview>
-    <p>The leap year rule for the Gregorian calendar, which has become the internationally accepted civil calendar, is: every year that is exactly divisible by four is a leap year, except for years that are exactly divisible by 100, but these centurial years are leap years if they are exactly divisible by 400.</p>
-    <p>A leap year bug occurs when software (in any language) is written without consideration of leap year logic, or with flawed logic to calculate leap years; which typically results in incorrect results.</p>
-    <p>The impact of these bugs may range from almost unnoticeable bugs such as an incorrect date, to severe bugs that affect reliability, availability or even the security of the affected system.</p>
-  </overview>
-
-  <references>
-    <li>U.S. Naval Observatory Website - <a href="https://aa.usno.navy.mil/faq/docs/calendars.php"> Introduction to Calendars</a></li>
-    <li>Wikipedia - <a href="https://en.wikipedia.org/wiki/Leap_year_bug"> Leap year bug</a> </li>
-    <li>Microsoft Azure blog - <a href="https://azure.microsoft.com/en-us/blog/is-your-code-ready-for-the-leap-year/"> Is your code ready for the leap year?</a> </li>
-  </references>
+<fragment>
+  <p>The leap year rule for the Gregorian calendar, which has become the internationally accepted civil calendar, is: every year that is exactly divisible by four is a leap year, except for years that are exactly divisible by 100, but these centurial years are leap years if they are exactly divisible by 400.</p>
+  <p>A leap year bug occurs when software (in any language) is written without consideration of leap year logic, or with flawed logic to calculate leap years; which typically results in incorrect results.</p>
+  <p>The impact of these bugs may range from almost unnoticeable bugs such as an incorrect date, to severe bugs that affect reliability, availability or even the security of the affected system.</p>
+</fragment>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Leap Year/LeapYearReferences.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/LeapYearReferences.qhelp
@@ -1,0 +1,10 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<fragment>
+  <li>U.S. Naval Observatory Website - <a href="https://aa.usno.navy.mil/faq/docs/calendars.php"> Introduction to Calendars</a></li>
+  <li>Wikipedia - <a href="https://en.wikipedia.org/wiki/Leap_year_bug"> Leap year bug</a> </li>
+  <li>Microsoft Azure blog - <a href="https://azure.microsoft.com/en-us/blog/is-your-code-ready-for-the-leap-year/"> Is your code ready for the leap year?</a> </li>
+</fragment>
+</qhelp>

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedLeapYearAfterYearModification.qhelp
@@ -21,4 +21,7 @@
 <sample src="UncheckedLeapYearAfterYearModificationGood.c" />
 </example>
 
+<references>
+  <include src="LeapYearReferences.qhelp" />
+</references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UncheckedReturnValueForTimeFunctions.qhelp
@@ -33,4 +33,7 @@
 <sample src="UncheckedLeapYearAfterYearModificationGood.c" />
 </example>
 
+<references>
+  <include src="LeapYearReferences.qhelp" />
+</references>
 </qhelp>

--- a/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.qhelp
+++ b/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.qhelp
@@ -22,4 +22,7 @@
 <sample src="UnsafeArrayForDaysOfYearGood.c" />
 </example>
 
+<references>
+  <include src="LeapYearReferences.qhelp" />
+</references>
 </qhelp>


### PR DESCRIPTION
I believe these changes will resolve the pull request check failures on https://github.com/Semmle/ql/pull/1354:
```
[2019-06-14T11:39:49.890Z] Exception: The following queries lack qhelp:
[2019-06-14T11:39:49.890Z]   semmlecode-cpp-queries/Likely Bugs/Leap Year/Adding365daysPerYear.ql
```
and
```
[2019-06-14T11:40:42.941Z] [2019-06-14 11:40:42] [ERROR] ql/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp: Expected a fragment but got overview
[2019-06-14T11:40:42.941Z] [2019-06-14 11:40:42] [ERROR] ql/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp is used by ql/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.qhelp
[2019-06-14T11:40:42.941Z] [2019-06-14 11:40:42] [ERROR] ql/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp: Expected a fragment but got references
[2019-06-14T11:40:42.941Z] [2019-06-14 11:40:42] [ERROR] ql/cpp/ql/src/Likely Bugs/Leap Year/LeapYear.qhelp is used by ql/cpp/ql/src/Likely Bugs/Leap Year/UnsafeArrayForDaysOfYear.qhelp
```
@semmledocs-ac please review, in particular the new `qhelp` file.